### PR TITLE
Closed the Scanner part (sc.close())

### DIFF
--- a/bubble_sort.java
+++ b/bubble_sort.java
@@ -31,5 +31,6 @@ public class bubble_sort
         {
             System.out.println(ar[i]);
         }
+        sc.close();
     }
 }


### PR DESCRIPTION
Closed the Scanner part using sc.close() to remove the warning shown while writing the code in compiler.